### PR TITLE
Use hashes when possible

### DIFF
--- a/HostsParser.Benchmarks/BenchmarkCollectionUtilities.cs
+++ b/HostsParser.Benchmarks/BenchmarkCollectionUtilities.cs
@@ -2,7 +2,6 @@
 // GNU General Public License v3.0
 
 using System.Collections.Generic;
-using System.Linq;
 using BenchmarkDotNet.Attributes;
 
 namespace HostsParser.Benchmarks
@@ -13,24 +12,9 @@ namespace HostsParser.Benchmarks
     {
         [Benchmark]
         [BenchmarkCategory(nameof(SortDnsList), nameof(CollectionUtilities))]
-        [ArgumentsSource(nameof(SourceWithBool))]
-        public List<string> SortDnsList(HashSet<string> data, bool distinct)
+        [ArgumentsSource(nameof(Source))]
+        public List<string> SortDnsList(HashSet<string> data)
             => CollectionUtilities.SortDnsList(data);
-
-        public IEnumerable<object[]> SourceWithBool()
-        {
-            var list = GetSource();
-            yield return new object[]
-            {
-                list,
-                true
-            };
-            yield return new object[]
-            {
-                list,
-                false
-            };
-        }
     }
 
     [MemoryDiagnoser]
@@ -42,11 +26,6 @@ namespace HostsParser.Benchmarks
         [ArgumentsSource(nameof(Source))]
         public Dictionary<int, List<string>> GroupDnsList(HashSet<string> data)
             => CollectionUtilities.GroupDnsList(data);
-
-        public IEnumerable<HashSet<string>> Source()
-        {
-            yield return GetSource();
-        }
     }
 
     [MemoryDiagnoser]
@@ -61,16 +40,11 @@ namespace HostsParser.Benchmarks
             CollectionUtilities.FilterGrouped(data);
             return data;
         }
-
-        public IEnumerable<HashSet<string>> Source()
-        {
-            yield return GetSource();
-        }
     }
 
     public abstract class BenchmarkCollectionUtilitiesBase : BenchmarkStreamBase
     {
-        protected static HashSet<string> GetSource()
+        public IEnumerable<HashSet<string>> Source()
         {
             var stream = PrepareStream();
             var source = HostUtilities
@@ -84,8 +58,8 @@ namespace HostsParser.Benchmarks
             stream.Dispose();
 
             source.UnionWith(adGuard);
-
-            return source;
+            
+            yield return source;
         }
     }
 }

--- a/HostsParser.Benchmarks/BenchmarkCollectionUtilities.cs
+++ b/HostsParser.Benchmarks/BenchmarkCollectionUtilities.cs
@@ -14,8 +14,8 @@ namespace HostsParser.Benchmarks
         [Benchmark]
         [BenchmarkCategory(nameof(SortDnsList), nameof(CollectionUtilities))]
         [ArgumentsSource(nameof(SourceWithBool))]
-        public List<string> SortDnsList(List<string> data, bool distinct)
-            => CollectionUtilities.SortDnsList(data, distinct);
+        public List<string> SortDnsList(HashSet<string> data, bool distinct)
+            => CollectionUtilities.SortDnsList(data);
 
         public IEnumerable<object[]> SourceWithBool()
         {
@@ -40,10 +40,10 @@ namespace HostsParser.Benchmarks
         [Benchmark]
         [BenchmarkCategory(nameof(GroupDnsList), nameof(CollectionUtilities))]
         [ArgumentsSource(nameof(Source))]
-        public Dictionary<int, List<string>> GroupDnsList(List<string> data)
+        public Dictionary<int, List<string>> GroupDnsList(HashSet<string> data)
             => CollectionUtilities.GroupDnsList(data);
 
-        public IEnumerable<List<string>> Source()
+        public IEnumerable<HashSet<string>> Source()
         {
             yield return GetSource();
         }
@@ -56,15 +56,13 @@ namespace HostsParser.Benchmarks
         [Benchmark]
         [BenchmarkCategory(nameof(FilterGrouped), nameof(CollectionUtilities))]
         [ArgumentsSource(nameof(Source))]
-        public List<string> FilterGrouped(List<string> data)
+        public HashSet<string> FilterGrouped(HashSet<string> data)
         {
-            var filtered = new HashSet<string>(data.Count);
-            CollectionUtilities.FilterGrouped(data, filtered);
-            data.RemoveAll(s => filtered.Contains(s));
+            CollectionUtilities.FilterGrouped(data);
             return data;
         }
 
-        public IEnumerable<List<string>> Source()
+        public IEnumerable<HashSet<string>> Source()
         {
             yield return GetSource();
         }
@@ -72,7 +70,7 @@ namespace HostsParser.Benchmarks
 
     public abstract class BenchmarkCollectionUtilitiesBase : BenchmarkStreamBase
     {
-        protected static List<string> GetSource()
+        protected static HashSet<string> GetSource()
         {
             var stream = PrepareStream();
             var source = HostUtilities
@@ -85,7 +83,9 @@ namespace HostsParser.Benchmarks
 
             stream.Dispose();
 
-            return source.Concat(adGuard).ToList();
+            source.UnionWith(adGuard);
+
+            return source;
         }
     }
 }

--- a/HostsParser.Benchmarks/BenchmarkCollectionUtilities.cs
+++ b/HostsParser.Benchmarks/BenchmarkCollectionUtilities.cs
@@ -40,7 +40,7 @@ namespace HostsParser.Benchmarks
         [Benchmark]
         [BenchmarkCategory(nameof(GroupDnsList), nameof(CollectionUtilities))]
         [ArgumentsSource(nameof(Source))]
-        public Dictionary<string, List<string>> GroupDnsList(List<string> data)
+        public Dictionary<int, List<string>> GroupDnsList(List<string> data)
             => CollectionUtilities.GroupDnsList(data);
 
         public IEnumerable<List<string>> Source()

--- a/HostsParser.Benchmarks/BenchmarkHostUtilities.cs
+++ b/HostsParser.Benchmarks/BenchmarkHostUtilities.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 

--- a/HostsParser.Benchmarks/BenchmarkHostUtilities.cs
+++ b/HostsParser.Benchmarks/BenchmarkHostUtilities.cs
@@ -23,7 +23,7 @@ namespace HostsParser.Benchmarks
 
         [Benchmark]
         [BenchmarkCategory(nameof(ProcessSource), nameof(HostUtilities))]
-        public async Task<List<string>> ProcessSource()
+        public async Task<HashSet<string>> ProcessSource()
         {
             return await HostUtilities.ProcessSource(_stream,
                 BenchmarkTestData.Settings.SkipLinesBytes,
@@ -56,10 +56,10 @@ namespace HostsParser.Benchmarks
         [Benchmark]
         [BenchmarkCategory(nameof(RemoveKnownBadHosts), nameof(HostUtilities))]
         [ArgumentsSource(nameof(Source))]
-        public void RemoveKnownBadHosts(List<string> data)
+        public void RemoveKnownBadHosts(HashSet<string> data)
             => HostUtilities.RemoveKnownBadHosts(BenchmarkTestData.Settings.KnownBadHosts, data);
 
-        public IEnumerable<List<string>> Source()
+        public IEnumerable<HashSet<string>> Source()
         {
             var stream = PrepareStream();
             var source = HostUtilities
@@ -72,7 +72,8 @@ namespace HostsParser.Benchmarks
 
             stream.Dispose();
 
-            yield return source.Concat(adGuard).ToList();
+            source.UnionWith(adGuard);
+            yield return source;
         }
     }
 }

--- a/HostsParser/CollectionUtilities.cs
+++ b/HostsParser/CollectionUtilities.cs
@@ -23,7 +23,11 @@ namespace HostsParser
         internal static void FilterGrouped(List<string> dnsList,
             HashSet<string> filtered)
         {
-            var hashSet = new HashSet<string>(dnsList);
+            var hashSet = new HashSet<int>(dnsList.Count);
+            for (var i = 0; i < dnsList.Count; i++)
+            {
+                hashSet.Add(dnsList[i].GetHashCode());
+            }
 
             var dnsGroups = GroupDnsList(dnsList);
             foreach (var (key, value) in dnsGroups)
@@ -34,21 +38,20 @@ namespace HostsParser
 
                 for (var index = 0; index < value.Count; index++)
                 {
-                    var current = value[index];
-                    if (key == current)
+                    if (key == value[index].GetHashCode())
                         continue;
 
-                    filtered.Add(current);
+                    filtered.Add(value[index]);
                 }
             }
         }
 
-        internal static Dictionary<string, List<string>> GroupDnsList(List<string> dnsList)
+        internal static Dictionary<int, List<string>> GroupDnsList(List<string> dnsList)
         {
-            var dict = new Dictionary<string, List<string>>(dnsList.Count);
+            var dict = new Dictionary<int, List<string>>(dnsList.Count);
             foreach (var s in dnsList)
             {
-                var key = GetTopMostDns(s).ToString();
+                var key = string.GetHashCode(GetTopMostDns(s));
                 List<string> values;
                 if (!dict.ContainsKey(key))
                 {

--- a/HostsParser/HostUtilities.cs
+++ b/HostsParser/HostUtilities.cs
@@ -16,20 +16,20 @@ namespace HostsParser
     {
         private static readonly Memory<char> Cache = new char[256];
 
-        internal static async Task<HashSet<string>> ProcessSource(Stream bytes,
+        internal static async Task<HashSet<string>> ProcessSource(Stream stream,
             byte[][] skipLines,
             Decoder decoder)
         {
-            var pipeReader = PipeReader.Create(bytes);
+            var pipeReader = PipeReader.Create(stream);
             var dnsList = new HashSet<string>(140_000);
             await ReadPipeAsync(pipeReader, dnsList, skipLines, decoder);
             return dnsList;
         }
 
-        internal static async Task<HashSet<string>> ProcessAdGuard(Stream bytes,
+        internal static async Task<HashSet<string>> ProcessAdGuard(Stream stream,
             Decoder decoder)
         {
-            var pipeReader = PipeReader.Create(bytes);
+            var pipeReader = PipeReader.Create(stream);
             var dnsList = new HashSet<string>(50_000);
             await ReadPipeAsync(pipeReader, dnsList, null, decoder);
             return dnsList;

--- a/HostsParser/HostUtilities.cs
+++ b/HostsParser/HostUtilities.cs
@@ -16,14 +16,14 @@ namespace HostsParser
     {
         private static readonly Memory<char> Cache = new char[256];
 
-        internal static async Task<List<string>> ProcessSource(Stream bytes,
+        internal static async Task<HashSet<string>> ProcessSource(Stream bytes,
             byte[][] skipLines,
             Decoder decoder)
         {
             var pipeReader = PipeReader.Create(bytes);
             var dnsList = new HashSet<string>(140_000);
             await ReadPipeAsync(pipeReader, dnsList, skipLines, decoder);
-            return new List<string>(dnsList);
+            return dnsList;
         }
 
         internal static async Task<HashSet<string>> ProcessAdGuard(Stream bytes,
@@ -35,14 +35,13 @@ namespace HostsParser
             return dnsList;
         }
 
-        internal static List<string> RemoveKnownBadHosts(string[] knownBadHosts,
-            List<string> hosts)
+        internal static HashSet<string> RemoveKnownBadHosts(string[] knownBadHosts,
+            HashSet<string> hosts)
         {
             var except = new List<string>(hosts.Count);
 
-            for (var i = 0; i < hosts.Count; i++)
+            foreach (var host in hosts)
             {
-                var host = hosts[i];
                 var found = false;
                 for (var j = 0; j < knownBadHosts.Length; j++)
                 {
@@ -51,11 +50,12 @@ namespace HostsParser
                     break;
                 }
 
-                if (!found)
+                if (found)
                     except.Add(host);
             }
 
-            return except;
+            hosts.ExceptWith(except);
+            return hosts;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/HostsParser/Program.cs
+++ b/HostsParser/Program.cs
@@ -58,31 +58,31 @@ namespace HostsParser
             combined.UnionWith(settings.KnownBadHosts);
             combined.UnionWith(adGuardLines);
             CollectionUtilities.FilterGrouped(combined);
-            
+
             var sortedDnsList = CollectionUtilities.SortDnsList(combined);
             HashSet<string> filtered = new(combined.Count);
             sortedDnsList = ProcessCombined(sortedDnsList, adGuardLines, filtered);
-            
+
             if (settings.ExtraFiltering)
             {
                 logger.LogInformation(WithTimeStamp("Start extra filtering of duplicates"));
                 sortedDnsList = ProcessWithExtraFiltering(adGuardLines, sortedDnsList, filtered);
                 logger.LogInformation(WithTimeStamp("Done extra filtering of duplicates"));
             }
-            
-            await using StreamWriter wr = new("hosts", false);
-            for (var i = 0; i < settings.HeaderLines.Length; i++)
-                await wr.WriteLineAsync(settings.HeaderLines[i]);
 
-            await wr.WriteLineAsync($"! Last Modified: {DateTime.UtcNow:u}");
-            
+            await using StreamWriter streamWriter = new("hosts", false);
+            for (var i = 0; i < settings.HeaderLines.Length; i++)
+                await streamWriter.WriteLineAsync(settings.HeaderLines[i]);
+
+            await streamWriter.WriteLineAsync($"! Last Modified: {DateTime.UtcNow:u}");
+
             foreach (var s in sortedDnsList)
             {
-                await wr.WriteLineAsync();
-                await wr.WriteAsync((char)Constants.PipeSign);
-                await wr.WriteAsync((char)Constants.PipeSign);
-                await wr.WriteAsync(s);
-                await wr.WriteAsync((char)Constants.HatSign);
+                await streamWriter.WriteLineAsync();
+                await streamWriter.WriteAsync((char)Constants.PipeSign);
+                await streamWriter.WriteAsync((char)Constants.PipeSign);
+                await streamWriter.WriteAsync(s);
+                await streamWriter.WriteAsync((char)Constants.HatSign);
             }
 
             stopWatch.Stop();
@@ -128,14 +128,14 @@ namespace HostsParser
                         AddIfSubDomain(filtered, item, otherItem);
                     }
                 });
-        
+
                 if (round == 1)
                     combined.RemoveAll(adGuardLines.Contains);
-        
+
                 combined.RemoveAll(filtered.Contains);
                 combined = CollectionUtilities.SortDnsList(combined);
             } while (filtered.Count > 0);
-        
+
             return combined;
         }
 


### PR DESCRIPTION
Use `HashSet` and hashes when possible to allocate less memory.