### PR TITLE
Better handling of short domains

### DIFF
--- a/src/HostsParser/CollectionUtilities.cs
+++ b/src/HostsParser/CollectionUtilities.cs
@@ -118,6 +118,7 @@ namespace HostsParser
                    || secondTop.Equals(Constants.TopDomains.Com, StringComparison.Ordinal)
                    || secondTop.Equals(Constants.TopDomains.Org, StringComparison.Ordinal)
                    || secondTop.Equals(Constants.TopDomains.Ne, StringComparison.Ordinal)
+                   || secondTop.Equals(Constants.TopDomains.Net, StringComparison.Ordinal)
                    || secondTop.Equals(Constants.TopDomains.Edu, StringComparison.Ordinal)
                    || secondTop.Equals(Constants.TopDomains.Or, StringComparison.Ordinal);
         }
@@ -153,7 +154,9 @@ namespace HostsParser
             }
             
             var slicedItem = item[(indexes[0] + 1)..indexes[1]];
-            return slicedItem.Length <= 3 ? item : item[(indexes[0] + 1)..];
+            // Check domains ending with x.y where x is shorter than 4 char against known second level top domains.
+            // If false, treat x.y as a domain so that any found sub domain will be sorted under it.
+            return IsSecondLevelTopDomain(slicedItem.Span) ? item : item[(indexes[0] + 1)..];
         }
 
         private static int IndexOf(in this ReadOnlySpan<char> aSpan,

--- a/src/HostsParser/CollectionUtilities.cs
+++ b/src/HostsParser/CollectionUtilities.cs
@@ -137,7 +137,9 @@ namespace HostsParser
             }
 
             var slicedItem = item[(indexes[0] + 1)..indexes[1]];
-            return slicedItem.Length <= 3 ? item : item[(indexes[0] + 1)..];
+            // Check domains ending with x.y where x is shorter than 4 char against known second level top domains.
+            // If false, treat x.y as a domain so that any found sub domain will be sorted under it.
+            return IsSecondLevelTopDomain(slicedItem) ? item : item[(indexes[0] + 1)..];
         }
 
         private static ReadOnlyMemory<char> ProcessItem(List<int> indexes,

--- a/src/HostsParser/Constants.cs
+++ b/src/HostsParser/Constants.cs
@@ -24,6 +24,7 @@ namespace HostsParser
             internal static ReadOnlySpan<char> Com => "com".AsSpan();
             internal static ReadOnlySpan<char> Org => "org".AsSpan();
             internal static ReadOnlySpan<char> Ne => "ne".AsSpan();
+            internal static ReadOnlySpan<char> Net => "net".AsSpan();
             internal static ReadOnlySpan<char> Edu => "edu".AsSpan();
             internal static ReadOnlySpan<char> Or => "or".AsSpan();
         }


### PR DESCRIPTION
Check domains ending with x.y where x is shorter than 4 char against known second level top domains. If false, treat x.y as a domain so that any found sub domain will be sorted under it.