### PR TITLE
Fix broken release action

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,8 +1,9 @@
 name: GitHub Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   release:


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
GitHub release doesn't work because action tries to push a tag that already exists.
This is caused by the action being triggered by the release event.

## PR Type
- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [x] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->