### PR TITLE
Fix broken GitHub Release

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,9 +1,8 @@
 name: GitHub Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types: [published]
 
 jobs:
   release:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -50,7 +50,7 @@ jobs:
           # Delete output directory
           rm -r "./release"
       - name: Publish
-        uses: softprops/action-gh-release@v0.1.11
+        uses: softprops/action-gh-release@v0.1.8
         with:
           files: |
             HostsParser*.zip

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -50,7 +50,7 @@ jobs:
           # Delete output directory
           rm -r "./release"
       - name: Publish
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.11
         with:
           files: |
             HostsParser*.zip


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
softprops/action-gh-release@v1 is broken, use v0.1.8 which should work.

## PR Type
- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [x] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->