### PR TITLE
Fix incorrect severity for IDE0011

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -258,7 +258,7 @@ dotnet_style_allow_statement_immediately_after_block_experimental = false
 # IDE0011: Add braces
 csharp_prefer_braces = false:suggestion
 # NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
-dotnet_diagnostic.IDE0011.severity = false
+dotnet_diagnostic.IDE0011.severity = suggestion
 
 # IDE0040: Add accessibility modifiers
 dotnet_diagnostic.IDE0040.severity = warning


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
`dotnet_diagnostic.IDE0011.severity` was set to `false`, which is invalid, should be `suggestion`.

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->