### PR TITLE
Fix mixup of source

### DIFF
--- a/src/HostsParser/Program.cs
+++ b/src/HostsParser/Program.cs
@@ -53,7 +53,7 @@ namespace HostsParser
             var adBlockBasedLines = new HashSet<string>(50_000);
             for (var i = 0; i < settings.AdBlockBased.SourceUris.Length; i++)
             {
-                await using var stream = await httpClient.GetStreamAsync(settings.HostsBased.SourceUris[i]);
+                await using var stream = await httpClient.GetStreamAsync(settings.AdBlockBased.SourceUris[i]);
                 await HostUtilities.ProcessAdBlockBased(adBlockBasedLines, stream, decoder);
             }
 


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
Fix bug where Hosts based URIs were used to load AdGuard data.

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->