### PR TITLE
Use LastIndexOf for subdomain lookup

### DIFF
--- a/src/HostsParser/HostUtilities.cs
+++ b/src/HostsParser/HostUtilities.cs
@@ -91,7 +91,7 @@ public static class HostUtilities
             || potentialDomain.Equals(potentialSubDomain, StringComparison.Ordinal))
             return false;
 
-        return potentialSubDomain[(potentialSubDomain.IndexOf(potentialDomain) - 1)..][0] == Constants.DotSign;
+        return potentialSubDomain[(potentialSubDomain.LastIndexOf(potentialDomain) - 1)..][0] == Constants.DotSign;
     }
 
     private static async Task ReadPipeAsync(PipeReader reader,


### PR DESCRIPTION
## Description
Fix index lookup when subdomain contains the same domain as the top domain.

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->