### PR TITLE
Restrict sarif upload

### DIFF
--- a/.github/workflows/qodana-action.yml
+++ b/.github/workflows/qodana-action.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           args: --baseline,qodana.sarif.json
       - uses: github/codeql-action/upload-sarif@v2
-        if: github.github.actor == 'dependabot'
+        if: github.github.actor != 'dependabot'
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/.github/workflows/qodana-action.yml
+++ b/.github/workflows/qodana-action.yml
@@ -22,5 +22,6 @@ jobs:
         with:
           args: --baseline,qodana.sarif.json
       - uses: github/codeql-action/upload-sarif@v2
+        if: github.github.actor == 'dependabot'
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json


### PR DESCRIPTION
## Description
Prevent dependabot from trying to upload sarif since it doesn't have access to a write token.

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->