### PR TITLE
Exclude dependabot[bot] from sarif upload

### DIFF
--- a/.github/workflows/qodana-action.yml
+++ b/.github/workflows/qodana-action.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           args: --baseline,qodana.sarif.json
       - uses: github/codeql-action/upload-sarif@v2
-        if: github.github.actor != 'dependabot'
+        if: github.github.actor != 'dependabot[bot]'
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
Exclude dependabot[bot] from sarif upload since it doesn't have access to tokens.

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->