### PR TITLE
Update xargs to use dynamic processor count in publish-filter workflow

### DIFF
--- a/.github/workflows/publish-filter.yml
+++ b/.github/workflows/publish-filter.yml
@@ -62,7 +62,9 @@ jobs:
           EOF
 
           chmod +x temp_script.sh
-          find ./artifacts/Configurations -name '*.json' -print0 | xargs -0 -I{} -P4 ./temp_script.sh "{}"
+          
+          NUM_PROCESSORS=$(nproc)
+          find ./artifacts/Configurations -name '*.json' -print0 | xargs -0 -I{} -P"$NUM_PROCESSORS" ./temp_script.sh "{}"
           rm temp_script.sh
 
       - name: Setup Pages


### PR DESCRIPTION
## Description
This commit adjusts the find/xargs call in the GitHub Actions workflow file "publish-filter.yml" to dynamically use the number of available processors. Previously the process was hardcoded to use four processors which wasn't ideal for systems with a different number of processors. Now, the 'nproc' command is used to assign the number of available processors to a variable 'NUM_PROCESSORS' and it is used as an argument value to '-P' option in xargs command. This change optimizes the execution of the temp_script.sh script by effectively utilizing the available resources in different systems.

## PR Type
- [ ] New feature
- [ ] Bug fix
- [x] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->