### PR TITLE
Add support for allowed exception rules in AdBlock format

### DIFF
--- a/src/HostsParser/Constants.cs
+++ b/src/HostsParser/Constants.cs
@@ -8,6 +8,7 @@ namespace HostsParser;
 internal readonly ref struct Constants
 {
     internal const byte PipeSign = (byte)'|';
+    internal const byte AtSign = (byte)'@';
     internal const byte HatSign = (byte)'^';
     internal const byte NewLine = (byte)'\n';
     internal const byte Space = (byte)' ';

--- a/tests/HostsParser.Benchmarks/BenchmarkCollectionUtilities.cs
+++ b/tests/HostsParser.Benchmarks/BenchmarkCollectionUtilities.cs
@@ -57,15 +57,17 @@ public abstract class BenchmarkCollectionUtilitiesBase : BenchmarkStreamBase
             .GetAwaiter().GetResult();
 
         stream = PrepareStream();
-        var externalCoverageLines = new HashSet<string>(50_000);
-        HostUtilities.ProcessAdBlockBased(externalCoverageLines,
+        var dnsHashSet = new HashSet<string>(50_000);
+        var allowedOverrides = new HashSet<string>(200);
+        HostUtilities.ProcessAdBlockBased(dnsHashSet,
+                allowedOverrides,
                 stream,
                 BenchmarkTestData.Decoder)
             .GetAwaiter().GetResult();
 
         stream.Dispose();
 
-        hostsBasedLines.UnionWith(externalCoverageLines);
+        hostsBasedLines.UnionWith(dnsHashSet);
 
         yield return hostsBasedLines;
     }

--- a/tests/HostsParser.Benchmarks/BenchmarkHostUtilities.cs
+++ b/tests/HostsParser.Benchmarks/BenchmarkHostUtilities.cs
@@ -46,6 +46,7 @@ public class BenchmarkProcessAdBlockBased : BenchmarkStreamBase
     [BenchmarkCategory(nameof(ProcessAdBlockBased), nameof(HostUtilities))]
     public async Task ProcessAdBlockBased()
         => await HostUtilities.ProcessAdBlockBased(new HashSet<string>(50_000),
+            new HashSet<string>(200),
             _stream!,
             BenchmarkTestData.Decoder);
 }
@@ -75,15 +76,17 @@ public class BenchmarkRemoveKnownBadHosts : BenchmarkStreamBase
             .GetAwaiter().GetResult();
 
         stream = PrepareStream();
-        var externalCoverageLines = new HashSet<string>(50_000);
-        HostUtilities.ProcessAdBlockBased(externalCoverageLines,
+        var dnsHashSet = new HashSet<string>(50_000);
+        var allowedOverrides = new HashSet<string>(200);
+        HostUtilities.ProcessAdBlockBased(dnsHashSet,
+                allowedOverrides,
                 stream,
                 BenchmarkTestData.Decoder)
             .GetAwaiter().GetResult();
 
         stream.Dispose();
 
-        hostsBasedLines.UnionWith(externalCoverageLines);
+        hostsBasedLines.UnionWith(dnsHashSet);
         yield return hostsBasedLines;
     }
 }

--- a/tests/HostsParser.Tests/HostUtilitiesTests.cs
+++ b/tests/HostsParser.Tests/HostUtilitiesTests.cs
@@ -89,9 +89,12 @@ public sealed class HostUtilitiesTests
                                      + "\n"
                                      + "||dns-c.com^ #Comment"
                                      + "\n"
+                                     + "@@||dns-d.com^"
+                                     + "\n"
                                      + "\n";
 
-        var expected = new HashSet<string> { "dns-a.com", "dns-b.com", "dns-c.com" };
+        var expectedBlocked = new HashSet<string> { "dns-a.com", "dns-b.com", "dns-c.com" };
+        var expectedAllowed = new HashSet<string> { "||dns-d.com" };
         await using var memoryStream = new MemoryStream();
         await using var streamWriter = new StreamWriter(memoryStream);
         await streamWriter.WriteAsync(AdBlockSource);
@@ -100,14 +103,19 @@ public sealed class HostUtilitiesTests
 
         var decoder = Encoding.UTF8.GetDecoder();
         var dnsCollection = new HashSet<string>();
+        var allowedOverrides = new HashSet<string>();
 
         // Act
-        await HostUtilities.ProcessAdBlockBased(dnsCollection, memoryStream, decoder);
+        await HostUtilities.ProcessAdBlockBased(dnsCollection, allowedOverrides, memoryStream, decoder);
 
         // Assert
         dnsCollection.Should().NotBeEmpty();
-        dnsCollection.Should().HaveSameCount(expected);
-        dnsCollection.Should().OnlyContain(s => expected.Contains(s));
+        dnsCollection.Should().HaveSameCount(expectedBlocked);
+        dnsCollection.Should().OnlyContain(s => expectedBlocked.Contains(s));
+
+        allowedOverrides.Should().NotBeEmpty();
+        allowedOverrides.Should().HaveSameCount(expectedAllowed);
+        allowedOverrides.Should().OnlyContain(s => expectedAllowed.Contains(s));
     }
 
     [Fact]


### PR DESCRIPTION
## Description
This update introduces the ability to handle allowed exception rules in AdBlock formatted files. In the AdBlock norm, '@@' at the beginning of the rule means it is an exception. The code is updated to recognize these rules, process them separately, and store them in a new HashSet<string> variable. This will distinguish which Domain Name System (DNS) requests to allow, enhancing the utility's flexibility and control over network traffic rules. The adjustment is accompanied by necessary changes in the tests, improving our project's robustness against future modifications.

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->