### PR TITLE
Don't publish AOT for ARM.

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -48,12 +48,20 @@ jobs:
           release_name="HostsParser-$tag-${{ matrix.target }}"
           # Build everything
           ASSEMBLY_VERSION="${tag//v}"
-          if [ "${{ matrix.target }}" == "win-x64" ] || [ "${{ matrix.target }}" == "win-arm64" ]; then
-            dotnet publish "./src/HostsParser/HostsParser.csproj" -r ${{ matrix.target }} -c Release -o release //p:Version="$ASSEMBLY_VERSION" //p:PublishAot=true
+          if [ "${{ matrix.kind }}" == "windows" ]; then
+            if [ "${{ matrix.target }}" == "win-x64" ]; then
+              dotnet publish "./src/HostsParser/HostsParser.csproj" -r ${{ matrix.target }} -c Release -o release //p:Version="$ASSEMBLY_VERSION" //p:PublishAot=true
+            else
+              dotnet publish "./src/HostsParser/HostsParser.csproj" -r ${{ matrix.target }} -c Release -o release //p:Version="$ASSEMBLY_VERSION"
+            fi
             # Pack to zip for Windows
             7z a -tzip "${release_name}.zip" "./release/*"
           else
-            dotnet publish "./src/HostsParser/HostsParser.csproj" -r ${{ matrix.target }} -c Release -o release /p:Version="$ASSEMBLY_VERSION" /p:PublishAot=true
+            if [[ "${{ matrix.target }}" == *arm64 ]]; then
+              dotnet publish "./src/HostsParser/HostsParser.csproj" -r ${{ matrix.target }} -c Release -o release /p:Version="$ASSEMBLY_VERSION"
+            else
+              dotnet publish "./src/HostsParser/HostsParser.csproj" -r ${{ matrix.target }} -c Release -o release /p:Version="$ASSEMBLY_VERSION" /p:PublishAot=true
+            fi
             # Pack tar.gz for non-Windows
             (cd ./release && tar czvf "../${release_name}.tar.gz" .)
           fi


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
GitHub Actions doesn't support ARM - publish those architectures without AOT.

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->