### PR TITLE
Fix dotnet publish command in GitHub workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -48,9 +48,9 @@ jobs:
               7z a -tzip "${release_name}.zip" "./release/*"
             else
               if [[ "$target" == *arm64 ]]; then
-                dotnet publish "./src/HostsParser/HostsParser.csproj" -r $target -c Release -o release //p:Version="$ASSEMBLY_VERSION"
+                dotnet publish "./src/HostsParser/HostsParser.csproj" -r $target -c Release -o release /p:Version="$ASSEMBLY_VERSION"
               else
-                dotnet publish "./src/HostsParser/HostsParser.csproj" -r $target -c Release -o release //p:Version="$ASSEMBLY_VERSION" //p:PublishAot=true
+                dotnet publish "./src/HostsParser/HostsParser.csproj" -r $target -c Release -o release /p:Version="$ASSEMBLY_VERSION" /p:PublishAot=true
               fi
               # Pack tar.gz for non-Windows
               tar -czvf "${release_name}.tar.gz" -C ./release .


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
Accidentally used double forward-slashes for non-Windows.

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->