### PR TITLE
Revert "Bump actions/deploy-pages from 3 to 4 (#258)"

### DIFF
--- a/.github/workflows/publish-filter.yml
+++ b/.github/workflows/publish-filter.yml
@@ -82,4 +82,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
<!--
* Give a brief summary of the issue and how the pull request is fixing it.
-->
This reverts commit 73e479255c1e87d231f445cac8bddf89310ff42f.
Uploads stopped working as part of upgrading to v4.
https://github.com/actions/deploy-pages/issues/284

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->