### PR TITLE
Switch to TUnit

### DIFF
--- a/tests/HostsParser.IntegrationTests/ExecutionUtilitiesTests.cs
+++ b/tests/HostsParser.IntegrationTests/ExecutionUtilitiesTests.cs
@@ -9,15 +9,13 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Xunit;
 
 namespace HostsParser.IntegrationTests;
 
 public sealed class ExecutionUtilitiesTests
 {
-    [Fact]
+    [Test]
     public async Task When_Running_Execute_MultiPassFilter_Toggle_Should_Differ_At_Most_Five()
     {
         // Arrange
@@ -39,10 +37,10 @@ public sealed class ExecutionUtilitiesTests
         // Assert
         // Sometimes there's one item in linesWithoutMultiPass that aren't in linesWithMultiPass.
         // This is "okay" because the sort isn't 100% stable and it's a tradeoff between performance and stability.
-        linesWithoutMultiPass.Should().NotBeEmpty();
-        linesWithMultiPass.Should().NotBeEmpty();
-        linesWithoutMultiPass.Except(linesWithMultiPass).Should().HaveCountLessThanOrEqualTo(5);
-        linesWithMultiPass.Except(linesWithoutMultiPass).Should().HaveCountLessThanOrEqualTo(5);
+        await Assert.That(linesWithoutMultiPass).IsNotEmpty();
+        await Assert.That(linesWithMultiPass).IsNotEmpty();
+        await Assert.That(linesWithoutMultiPass.Except(linesWithMultiPass)).HasCount().LessThanOrEqualTo(5);
+        await Assert.That(linesWithMultiPass.Except(linesWithoutMultiPass)).HasCount().LessThanOrEqualTo(5);
     }
 }
 

--- a/tests/HostsParser.IntegrationTests/HostsParser.IntegrationTests.csproj
+++ b/tests/HostsParser.IntegrationTests/HostsParser.IntegrationTests.csproj
@@ -7,17 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="TUnit" Version="0.12.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/HostsParser.Tests/CollectionUtilitiesTests.cs
+++ b/tests/HostsParser.Tests/CollectionUtilitiesTests.cs
@@ -2,15 +2,15 @@
 // GNU General Public License v3.0
 
 using System.Collections.Generic;
-using FluentAssertions;
-using Xunit;
+using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 
 namespace HostsParser.Tests;
 
 public sealed class CollectionUtilitiesTests
 {
-    [Fact]
-    public void SortDnsList_Should_Be_Ordered()
+    [Test]
+    public async Task SortDnsList_Should_Be_Ordered()
     {
         // Arrange
         var dnsCollection = new List<string>
@@ -39,12 +39,12 @@ public sealed class CollectionUtilitiesTests
         var sortDnsList = CollectionUtilities.SortDnsList(shuffled);
 
         // Assert
-        sortDnsList.Should().NotBeNullOrEmpty();
-        sortDnsList.Should().ContainInOrder(dnsCollection);
+        await Assert.That(sortDnsList).IsNotEmpty()
+            .And.IsEquivalentTo(dnsCollection, CollectionOrdering.Matching);
     }
 
-    [Fact]
-    public void FilterGrouped_Should_Not_Contain_SubDomains()
+    [Test]
+    public async Task FilterGrouped_Should_Not_Contain_SubDomains()
     {
         // Arrange
         var dnsCollection = new HashSet<string>
@@ -65,8 +65,7 @@ public sealed class CollectionUtilitiesTests
         CollectionUtilities.FilterGrouped(dnsCollection);
 
         // Assert
-        dnsCollection.Should().NotBeNullOrEmpty();
-        dnsCollection.Should().HaveSameCount(expected);
-        dnsCollection.Should().OnlyContain(s => expected.Contains(s));
+        await Assert.That(dnsCollection).HasCount().EqualTo(expected.Count)
+            .And.ContainsOnly(s => expected.Contains(s));
     }
 }

--- a/tests/HostsParser.Tests/HostUtilitiesTests.cs
+++ b/tests/HostsParser.Tests/HostUtilitiesTests.cs
@@ -6,14 +6,12 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using FluentAssertions;
-using Xunit;
 
 namespace HostsParser.Tests;
 
 public sealed class HostUtilitiesTests
 {
-    [Fact]
+    [Test]
     public async Task ProcessHostsBased_Should_Only_Return_Dns_Entries()
     {
         // Arrange
@@ -64,12 +62,11 @@ public sealed class HostUtilitiesTests
             decoder);
 
         // Assert
-        dnsCollection.Should().NotBeEmpty();
-        dnsCollection.Should().HaveSameCount(expected);
-        dnsCollection.Should().OnlyContain(s => expected.Contains(s));
+        await Assert.That(dnsCollection).HasCount().EqualTo(expected.Count).And
+            .ContainsOnly(s => expected.Contains(s));
     }
 
-    [Fact]
+    [Test]
     public async Task ProcessAdBlockBased_Should_Only_Return_Dns_Entries()
     {
         // Arrange
@@ -109,17 +106,15 @@ public sealed class HostUtilitiesTests
         await HostUtilities.ProcessAdBlockBased(dnsCollection, allowedOverrides, memoryStream, decoder);
 
         // Assert
-        dnsCollection.Should().NotBeEmpty();
-        dnsCollection.Should().HaveSameCount(expectedBlocked);
-        dnsCollection.Should().OnlyContain(s => expectedBlocked.Contains(s));
+        await Assert.That(dnsCollection).HasCount().EqualTo(expectedBlocked.Count).And
+            .ContainsOnly(s => expectedBlocked.Contains(s));
 
-        allowedOverrides.Should().NotBeEmpty();
-        allowedOverrides.Should().HaveSameCount(expectedAllowed);
-        allowedOverrides.Should().OnlyContain(s => expectedAllowed.Contains(s));
+        await Assert.That(allowedOverrides).HasCount().EqualTo(expectedAllowed.Count).And
+            .ContainsOnly(s => expectedAllowed.Contains(s));
     }
 
-    [Fact]
-    public void RemoveKnownBadHosts_Should_Remove_All_SubDomain_Entries_Of_Known_Bad_Hosts()
+    [Test]
+    public async Task RemoveKnownBadHosts_Should_Remove_All_SubDomain_Entries_Of_Known_Bad_Hosts()
     {
         // Arrange
         var knownBadHosts = new[] { "bad-dns.com", "another-bad-dns.co.com" };
@@ -138,18 +133,17 @@ public sealed class HostUtilitiesTests
         dnsCollection = HostUtilities.RemoveKnownBadHosts(knownBadHosts, dnsCollection);
 
         // Assert
-        dnsCollection.Should().NotBeEmpty();
-        dnsCollection.Should().HaveSameCount(expected);
-        dnsCollection.Should().OnlyContain(s => expected.Contains(s));
+        await Assert.That(dnsCollection).HasCount().EqualTo(expected.Count).And
+            .ContainsOnly(s => expected.Contains(s));
     }
 
-    [Theory]
-    [InlineData("subdomain.domain.com", "domain.com", true)]
-    [InlineData("a.subdomain.domain.com", "domain.com", true)]
-    [InlineData("subdomain.domain.co.com", "domain.co.com", true)]
-    [InlineData("different.subdomain.com", "domain.com", false)]
-    [InlineData("b.different.subdomain.com", "domain.com", false)]
-    public void IsSubDomainOf_Should_Validate_SubDomain(string potentialSubDomain,
+    [Test]
+    [Arguments("subdomain.domain.com", "domain.com", true)]
+    [Arguments("a.subdomain.domain.com", "domain.com", true)]
+    [Arguments("subdomain.domain.co.com", "domain.co.com", true)]
+    [Arguments("different.subdomain.com", "domain.com", false)]
+    [Arguments("b.different.subdomain.com", "domain.com", false)]
+    public async Task IsSubDomainOf_Should_Validate_SubDomain(string potentialSubDomain,
         string potentialDomain,
         bool expected)
     {
@@ -158,6 +152,6 @@ public sealed class HostUtilitiesTests
         var isSubDomainOf = HostUtilities.IsSubDomainOf(potentialSubDomain, potentialDomain);
 
         // Assert
-        isSubDomainOf.Should().Be(expected);
+        await Assert.That(isSubDomainOf).IsEqualTo(expected);
     }
 }

--- a/tests/HostsParser.Tests/HostsParser.Tests.csproj
+++ b/tests/HostsParser.Tests/HostsParser.Tests.csproj
@@ -11,17 +11,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="TUnit" Version="0.12.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/HostsParser.Tests/HostsParserLoggerTests.cs
+++ b/tests/HostsParser.Tests/HostsParserLoggerTests.cs
@@ -3,16 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using FluentAssertions;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace HostsParser.Tests;
 
 public sealed class HostsParserLoggerTests
 {
-    [Fact]
-    public void Running_Should_Log_Text()
+    [Test]
+    public async Task Running_Should_Log_Text()
     {
         // Arrange
         var store = new List<string>();
@@ -22,11 +21,12 @@ public sealed class HostsParserLoggerTests
         logger.Running();
 
         // Assert
-        store.Should().HaveCount(1).And.ContainSingle(static s => s == "Information-1-Running-Running...");
+        await Assert.That(store).HasSingleItem().And
+            .ContainsOnly(static s => s == "Information-1-Running-Running...");
     }
 
-    [Fact]
-    public void UnableToRun_Should_Log_Text()
+    [Test]
+    public async Task UnableToRun_Should_Log_Text()
     {
         // Arrange
         var store = new List<string>();
@@ -36,12 +36,12 @@ public sealed class HostsParserLoggerTests
         logger.UnableToRun();
 
         // Assert
-        store.Should().HaveCount(1).And
-            .ContainSingle(static s => s == "Error-2-UnableToRun-Couldn't load settings. Terminating...");
+        await Assert.That(store).HasSingleItem().And
+            .ContainsOnly(static s => s == "Error-2-UnableToRun-Couldn't load settings. Terminating...");
     }
 
-    [Fact]
-    public void StartExtraFiltering_Should_Log_Text()
+    [Test]
+    public async Task StartExtraFiltering_Should_Log_Text()
     {
         // Arrange
         var store = new List<string>();
@@ -51,12 +51,12 @@ public sealed class HostsParserLoggerTests
         logger.StartExtraFiltering();
 
         // Assert
-        store.Should().HaveCount(1).And.ContainSingle(static s =>
-            s == "Information-3-StartExtraFiltering-Start extra filtering of duplicates.");
+        await Assert.That(store).HasSingleItem().And
+            .ContainsOnly(static s => s == "Information-3-StartExtraFiltering-Start extra filtering of duplicates.");
     }
 
-    [Fact]
-    public void DoneExtraFiltering_Should_Log_Text()
+    [Test]
+    public async Task DoneExtraFiltering_Should_Log_Text()
     {
         // Arrange
         var store = new List<string>();
@@ -66,12 +66,12 @@ public sealed class HostsParserLoggerTests
         logger.DoneExtraFiltering();
 
         // Assert
-        store.Should().HaveCount(1).And
-            .ContainSingle(static s => s == "Information-4-DoneExtraFiltering-Done extra filtering of duplicates.");
+        await Assert.That(store).HasSingleItem().And
+            .ContainsOnly(static s => s == "Information-4-DoneExtraFiltering-Done extra filtering of duplicates.");
     }
 
-    [Fact]
-    public void Finalized_Should_Log_Text()
+    [Test]
+    public async Task Finalized_Should_Log_Text()
     {
         // Arrange
         var store = new List<string>();
@@ -83,8 +83,8 @@ public sealed class HostsParserLoggerTests
         logger.Finalized(timeSpan, Count);
 
         // Assert
-        store.Should().HaveCount(1).And.ContainSingle(s =>
-            s == $"Information-5-Finalized-Execution duration - {timeSpan} | Produced {Count} hosts.");
+        await Assert.That(store).HasSingleItem().And
+            .ContainsOnly( s => s == $"Information-5-Finalized-Execution duration - {timeSpan} | Produced {Count} hosts.");
     }
 }
 

--- a/tests/HostsParser.Tests/ProcessingUtilitiesTests.cs
+++ b/tests/HostsParser.Tests/ProcessingUtilitiesTests.cs
@@ -2,15 +2,14 @@
 // GNU General Public License v3.0
 
 using System.Collections.Generic;
-using FluentAssertions;
-using Xunit;
+using System.Threading.Tasks;
 
 namespace HostsParser.Tests;
 
 public sealed class ProcessingUtilitiesTests
 {
-    [Fact]
-    public void ProcessCombined_Should_Remove_Redundant_Entries()
+    [Test]
+    public async Task ProcessCombined_Should_Remove_Redundant_Entries()
     {
         // Arrange
         var sortedDnsList = new List<string>
@@ -34,13 +33,12 @@ public sealed class ProcessingUtilitiesTests
             filteredCache);
 
         // Assert
-        sortedDnsList.Should().NotBeEmpty();
-        sortedDnsList.Should().HaveSameCount(expected);
-        sortedDnsList.Should().OnlyContain(s => expected.Contains(s));
+        await Assert.That(sortedDnsList).HasCount().EqualTo(expected.Count)
+            .And.ContainsOnly(s => expected.Contains(s));
     }
 
-    [Fact]
-    public void ProcessCombinedWithMultipleRounds_Should_Remove_Redundant_Entries()
+    [Test]
+    public async Task ProcessCombinedWithMultipleRounds_Should_Remove_Redundant_Entries()
     {
         // Arrange
         var sortedDnsList = new List<string>
@@ -64,13 +62,12 @@ public sealed class ProcessingUtilitiesTests
             filteredCache);
 
         // Assert
-        sortedDnsList.Should().NotBeEmpty();
-        sortedDnsList.Should().HaveSameCount(expected);
-        sortedDnsList.Should().OnlyContain(s => expected.Contains(s));
+        await Assert.That(sortedDnsList).HasCount().EqualTo(expected.Count)
+            .And.ContainsOnly(s => expected.Contains(s));
     }
 
-    [Fact]
-    public void ProcessWithExtraFiltering_Should_Remove_All_Matching_SubDomains()
+    [Test]
+    public async Task ProcessWithExtraFiltering_Should_Remove_All_Matching_SubDomains()
     {
         // Arrange
         var sortedDnsList = new List<string>
@@ -94,8 +91,7 @@ public sealed class ProcessingUtilitiesTests
             filteredCache);
 
         // Assert
-        sortedDnsList.Should().NotBeEmpty();
-        sortedDnsList.Should().HaveSameCount(expected);
-        sortedDnsList.Should().OnlyContain(s => expected.Contains(s));
+        await Assert.That(sortedDnsList).HasCount().EqualTo(expected.Count)
+            .And.ContainsOnly(s => expected.Contains(s));
     }
 }


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
Switch to TUnit in order to get rid of FluentAssertion and still have nice assertions.

## PR Type
- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->