### PR TITLE
Fix failing runs by always acquiring lock when adding

### DIFF
--- a/src/HostsParser/HostUtilities.cs
+++ b/src/HostsParser/HostUtilities.cs
@@ -261,17 +261,9 @@ public static class HostUtilities
 
     private static void AddItem(ICollection<string> resultCollection, string item)
     {
-        try
+        lock (Lock)
         {
             resultCollection.Add(item);
-        }
-        catch (InvalidOperationException)
-        {
-            // Try add again if collection was modified.
-            lock (Lock)
-            {
-                resultCollection.Add(item);
-            }
         }
     }
 


### PR DESCRIPTION
<!--
* Thank you for investing your time on improving this project! Please fill out the forms below to the best of your ability.
-->

## Description
Publish of new filters keep failing because the collection entries are added to isn't synchronized.

## PR Type
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Unit tests
- [ ] Branch merge
- [ ] Docs
- [ ] Other (please describe in description)

## Fixes Issue(s)
<!--
* Provide Issue Number(s)
-->